### PR TITLE
Update RHINO_PLUG_IN_DESCRIPTION

### DIFF
--- a/RPCPlugIn.cpp
+++ b/RPCPlugIn.cpp
@@ -41,7 +41,7 @@ RHINO_PLUG_IN_VERSION(__DATE__ "  " __TIME__)
 
 // Rhino plug-in description
 // Provide a description of this plug-in.
-RHINO_PLUG_IN_DESCRIPTION(L"RPC plug-in for Rhinoceros®");
+RHINO_PLUG_IN_DESCRIPTION(L"RPC plug-in for Rhinoceros");
 
 // Rhino plug-in icon resource id
 // Provide an icon resource this plug-in.


### PR DESCRIPTION
Rhino doesn't correctly use the right code page for RHINO_PLUG_IN_DESCRIPTION causing malform characters when using two byte UTF-8 character encoding. So instead of seeing ©, it shows Â©.  This appears to be the only plugin that using two byte UTF-8 in the plugin description so the simplest solution is just to remove this character.